### PR TITLE
checkBalance looks for a 16 byte, zero-filled hex value

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -44,7 +44,7 @@ Get whether or not the library is ready to be used ([#module_NanoCurrency.init](
 <a name="module_NanoCurrency.checkBalance"></a>
 
 ### NanoCurrency.checkBalance(balance) ⇒ <code>boolean</code>
-Check if the given balance is valid.
+Check if the given balance is valid. 
 Does not require initialization.
 
 **Kind**: static method of [<code>NanoCurrency</code>](#module_NanoCurrency)  
@@ -52,7 +52,7 @@ Does not require initialization.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| balance | <code>string</code> | The balance to check |
+| balance | <code>string</code> | The balance to check. Balance must contain a 16 byte, zero-filled hex value. |
 
 <a name="module_NanoCurrency.checkSeed"></a>
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,14 +70,13 @@ const checkString = candidate => typeof candidate === 'string'
  * Does not require initialization.
  *
  * @function
- * @param {string} balance - The balance to check
+ * @param {string} balance - The balance to check. Balance must contain a 16 byte, zero-filled hex value.
  * @return {boolean} Valid
  */
 export const checkBalance = balance => {
-  if (!checkString(balance) || balance.length > 39) return false
-  for (let char of balance) {
-    if (char < '0' || char > '9') return false
-  }
+  const isSixteenByteHex = balance.length === 32 && balance.match(/([0-9]|[a-f])/gi).length === balance.length
+
+  if (!checkString(balance) || !isSixteenByteHex) return false
 
   return true
 }


### PR DESCRIPTION
I had been trying to use `createSendBlock` to create a block which I could then send using my desktop wallet but was having no success. After a time I discovered that the `balance` property in the `data` object should not be a raw value in string format, rather a 16 byte, zero-filled hex value in string format.

To see this have a look at this video at the 13 minute 34 seconds mark https://youtu.be/Ojmv8B5ttFs?t=13m34s You will see that the balance format returned from getting the Nano node to create a block is a 16 byte, zero-filled hex value.

After performing some tests of my own using the hex value worked whereas the raw value just got rejected.