### PR TITLE
Better support for universal open block

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -36,7 +36,11 @@ export interface BlockData {
 export function createBlock(secretKey: string, data: BlockData) {
   if (!checkKey(secretKey)) throw new Error('Secret key is not valid');
   if (typeof data.work === 'undefined') throw new Error('Work is not set');
-  if (!checkHash(data.previous)) throw new Error('Previous is not valid');
+  if(!data.previous === '0') {
+    if (!checkHash(data.previous)) throw new Error('Previous is not valid');
+  } else {
+    data.previous = '0000000000000000000000000000000000000000000000000000000000000000';
+  }
   if (!checkAddress(data.representative)) {
     throw new Error('Representative is not valid');
   }


### PR DESCRIPTION
As per NEP-01 added better support for open block. If user calls createBlock() with previous: '0', we can handle the change to '0000000000000000000000000000000000000000000000000000000000000000' automaically as per the RPC command.