### PR TITLE
Add the capability to calculate work difficulty and difficulty multiplier

### DIFF
--- a/packages/nanocurrency/__tests__/work.js
+++ b/packages/nanocurrency/__tests__/work.js
@@ -85,3 +85,74 @@ describe('validation', () => {
     }
   })
 })
+
+describe('difficulty', () => {
+  test('calculates correct difficulty', () => {
+    expect(
+      nano.getWorkDifficulty({
+        blockHash: '7E5E6CBC887A30464FB2E0573455D9384C639D23F638430922445AE628697121',
+        work: 'ce00225c66af3e69',
+      })
+    ).toBe('fffffffba684718d')
+  })
+
+  test('throws with invalid hashes', () => {
+    expect.assertions(INVALID_HASHES.length)
+    for (let invalidHash of INVALID_HASHES) {
+      expect(() =>
+        nano.getWorkDifficulty({
+          blockHash: invalidHash,
+          work: RANDOM_VALID_BLOCK.block.data.work,
+        })
+      ).toThrowError('Hash is not valid')
+    }
+  })
+
+  test('throws with invalid works', () => {
+    expect.assertions(INVALID_WORKS.length)
+    for (let invalidWork of INVALID_WORKS) {
+      expect(() =>
+        nano.getWorkDifficulty({
+          blockHash: RANDOM_VALID_BLOCK.block.hash,
+          work: invalidWork,
+        })
+      ).toThrowError('Work is not valid')
+    }
+  })
+})
+
+describe('multiplier', () => {
+  test('calculates correct multiplier', () => {
+    expect(
+      nano.getDifficultyMultiplier({
+        difficulty: 'fffffffba684718d',
+      })
+    ).toBeCloseTo(14.714194345574768, 10)
+  })
+
+  test('throws with invalid difficulty', () => {
+    expect.assertions(INVALID_THRESHOLDS.length)
+    for (const invalidThreshold of INVALID_THRESHOLDS) {
+      expect(() =>
+        nano.getDifficultyMultiplier({
+          difficulty: invalidThreshold,
+        })
+      ).toThrowError('Difficulty is not valid')
+    }
+  })
+
+  test('throws with invalid threshold', () => {
+    expect.assertions(INVALID_THRESHOLDS.length)
+    for (const invalidThreshold of INVALID_THRESHOLDS) {
+      expect(() =>
+        nano.getDifficultyMultiplier({
+          difficulty: nano.getWorkDifficulty({
+            blockHash: RANDOM_VALID_BLOCK.block.hash,
+            work: RANDOM_VALID_BLOCK.block.data.work,
+          }),
+          threshold: invalidThreshold,
+        })
+      ).toThrowError('Threshold is not valid')
+    }
+  })
+})

--- a/packages/nanocurrency/src/index.ts
+++ b/packages/nanocurrency/src/index.ts
@@ -44,4 +44,4 @@ export {
   verifyBlock,
   VerifyBlockParams,
 } from './signature'
-export { validateWork, ValidateWorkParams } from './work'
+export { validateWork, ValidateWorkParams, getWorkDifficulty, GetDifficultyMultiplierParams, getDifficultyMultiplier, GetWorkDifficultyParams } from './work'

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -10,14 +10,12 @@ import { byteArrayToHex, hexToByteArray } from './utils'
 
 export const DEFAULT_WORK_THRESHOLD = 'ffffffc000000000'
 
-/** Validate work parameters. */
-export interface ValidateWorkParams {
-  /** The block hash to validate the work against */
+/** Get work difficulty parameters. */
+export interface GetWorkDifficultyParams {
+  /** The block hash to check the work against */
   blockHash: string
-  /** The work to validate */
+  /** The work to check */
   work: string
-  /** The threshold to validate against. Defaults to ffffffc000000000 */
-  threshold?: string
 }
 
 /** @hidden */
@@ -39,6 +37,27 @@ export function getWorkDifficultyBigNumber(params: GetWorkDifficultyParams): Big
 }
 
 /**
+ * Get the work difficulty for the given hash.
+ *
+ * @param params - Parameters
+ * @returns Difficulty
+ */
+export function getWorkDifficulty(params: GetWorkDifficultyParams): string {
+  const outputBigNumber = getWorkDifficultyBigNumber({ blockHash: params.blockHash, work: params.work })
+  return outputBigNumber.toString(16);
+}
+
+/** Validate work parameters. */
+export interface ValidateWorkParams {
+  /** The block hash to validate the work against */
+  blockHash: string
+  /** The work to validate */
+  work: string
+  /** The threshold to validate against. Defaults to ffffffc000000000 */
+  threshold?: string
+}
+
+/**
  * Validate whether or not the work value meets the difficulty for the given hash.
  *
  * @param params - Parameters
@@ -53,25 +72,6 @@ export function validateWork(params: ValidateWorkParams): boolean {
   const threshold = new BigNumber(`0x${thresholdHex}`)
 
   return outputBigNumber.isGreaterThanOrEqualTo(threshold)
-}
-
-/** Get work difficulty parameters. */
-export interface GetWorkDifficultyParams {
-  /** The block hash to check the work against */
-  blockHash: string
-  /** The work to check */
-  work: string
-}
-
-/**
- * Get the work difficulty for the given hash.
- *
- * @param params - Parameters
- * @returns Difficulty
- */
-export function getWorkDifficulty(params: GetWorkDifficultyParams): string {
-  const outputBigNumber = getWorkDifficultyBigNumber({ blockHash: params.blockHash, work: params.work })
-  return outputBigNumber.toString(16);
 }
 
 /** Get work multiplier parameters. */

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -10,64 +10,6 @@ import { byteArrayToHex, hexToByteArray } from './utils'
 
 export const DEFAULT_WORK_THRESHOLD = 'ffffffc000000000'
 
-/** Get work difficulty parameters. */
-export interface GetWorkDifficultyParams {
-  /** The block hash to check the work against */
-  blockHash: string
-  /** The work to check */
-  work: string
-}
-
-/**
- * Get the work difficulty for the given hash.
- *
- * @param params - Parameters
- * @returns Difficulty
- */
-export function getWorkDifficulty(params: GetWorkDifficultyParams): BigNumber {
-  if (!checkHash(params.blockHash)) throw new Error('Hash is not valid')
-  if (!checkWork(params.work)) throw new Error('Work is not valid')
-
-  const hashBytes = hexToByteArray(params.blockHash)
-  const workBytes = hexToByteArray(params.work).reverse()
-
-  const context = blake2bInit(8)
-  blake2bUpdate(context, workBytes)
-  blake2bUpdate(context, hashBytes)
-  const output = blake2bFinal(context).reverse()
-  const outputHex = byteArrayToHex(output)
-  const outputBigNumber = new BigNumber(`0x${outputHex}`)
-
-  return outputBigNumber;
-}
-
-/** Get work multiplier parameters. */
-export interface GetWorkMultiplierParams {
-  /** The block hash to check the work against */
-  blockHash: string
-  /** The work to check */
-  work: string
-  /** The threshold to check against. Defaults to ffffffc000000000 */
-  threshold?: string
-}
-
-/**
- * Get the difficulty multiplier of a work for the given hash.
- *
- * @param params - Parameters
- * @returns Multiplier
- */
-export function getDifficultyMultiplier(params: GetWorkMultiplierParams): number {
-  const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
-
-  if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
-
-  const difficulty = getWorkDifficulty({ blockHash: params.blockHash, work: params.work });
-  const threshold = new BigNumber(`0x${thresholdHex}`)
-
-  return threshold.dividedBy(difficulty).toNumber();
-}
-
 /** Validate work parameters. */
 export interface ValidateWorkParams {
   /** The block hash to validate the work against */
@@ -87,10 +29,75 @@ export interface ValidateWorkParams {
 export function validateWork(params: ValidateWorkParams): boolean {
   const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
 
+  if (!checkHash(params.blockHash)) throw new Error('Hash is not valid')
+  if (!checkWork(params.work)) throw new Error('Work is not valid')
   if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
 
-  const difficulty = getWorkDifficulty({ blockHash: params.blockHash, work: params.work });
   const threshold = new BigNumber(`0x${thresholdHex}`)
+  const hashBytes = hexToByteArray(params.blockHash)
+  const workBytes = hexToByteArray(params.work).reverse()
 
-  return difficulty.isGreaterThanOrEqualTo(threshold);
+  const context = blake2bInit(8)
+  blake2bUpdate(context, workBytes)
+  blake2bUpdate(context, hashBytes)
+  const output = blake2bFinal(context).reverse()
+  const outputHex = byteArrayToHex(output)
+  const outputBigNumber = new BigNumber(`0x${outputHex}`)
+
+  return outputBigNumber.isGreaterThanOrEqualTo(threshold)
+}
+
+/** Get work difficulty parameters. */
+export interface GetWorkDifficultyParams {
+  /** The block hash to check the work against */
+  blockHash: string
+  /** The work to check */
+  work: string
+}
+
+/**
+ * Get the work difficulty for the given hash.
+ *
+ * @param params - Parameters
+ * @returns Difficulty
+ */
+export function getWorkDifficulty(params: GetWorkDifficultyParams): string {
+  if (!checkHash(params.blockHash)) throw new Error('Hash is not valid')
+  if (!checkWork(params.work)) throw new Error('Work is not valid')
+
+  const hashBytes = hexToByteArray(params.blockHash)
+  const workBytes = hexToByteArray(params.work).reverse()
+
+  const context = blake2bInit(8)
+  blake2bUpdate(context, workBytes)
+  blake2bUpdate(context, hashBytes)
+  const output = blake2bFinal(context).reverse()
+  const outputHex = byteArrayToHex(output)
+  const outputBigNumber = new BigNumber(`0x${outputHex}`)
+
+  return outputBigNumber.toString(16);
+}
+
+/** Get work multiplier parameters. */
+export interface GetDifficultyMultiplierParams {
+  /** The block hash to check the work against */
+  difficulty: string
+  threshold?: string
+}
+
+/**
+ * Get the difficulty multiplier of a work for the given hash.
+ *
+ * @param params - Parameters
+ * @returns Multiplier
+ */
+export function getDifficultyMultiplier(params: GetDifficultyMultiplierParams): number {
+  const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
+
+  if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
+
+  const threshold = new BigNumber(`0x${thresholdHex}`)
+  const difficulty = new BigNumber(`0x${params.difficulty}`)
+
+  return threshold.dividedBy(difficulty).toNumber();
 }

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -10,6 +10,64 @@ import { byteArrayToHex, hexToByteArray } from './utils'
 
 export const DEFAULT_WORK_THRESHOLD = 'ffffffc000000000'
 
+/** Get work difficulty parameters. */
+export interface GetWorkDifficultyParams {
+  /** The block hash to check the work against */
+  blockHash: string
+  /** The work to check */
+  work: string
+}
+
+/**
+ * Get the work difficulty for the given hash.
+ *
+ * @param params - Parameters
+ * @returns Difficulty
+ */
+export function getWorkDifficulty(params: GetWorkDifficultyParams): BigNumber {
+  if (!checkHash(params.blockHash)) throw new Error('Hash is not valid')
+  if (!checkWork(params.work)) throw new Error('Work is not valid')
+
+  const hashBytes = hexToByteArray(params.blockHash)
+  const workBytes = hexToByteArray(params.work).reverse()
+
+  const context = blake2bInit(8)
+  blake2bUpdate(context, workBytes)
+  blake2bUpdate(context, hashBytes)
+  const output = blake2bFinal(context).reverse()
+  const outputHex = byteArrayToHex(output)
+  const outputBigNumber = new BigNumber(`0x${outputHex}`)
+
+  return outputBigNumber;
+}
+
+/** Get work multiplier parameters. */
+export interface GetWorkMultiplierParams {
+  /** The block hash to check the work against */
+  blockHash: string
+  /** The work to check */
+  work: string
+  /** The threshold to check against. Defaults to ffffffc000000000 */
+  threshold?: string
+}
+
+/**
+ * Get the difficulty multiplier of a work for the given hash.
+ *
+ * @param params - Parameters
+ * @returns Multiplier
+ */
+export function getDifficultyMultiplier(params: GetWorkMultiplierParams): number {
+  const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
+
+  if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
+
+  const difficulty = getWorkDifficulty({ blockHash: params.blockHash, work: params.work });
+  const threshold = new BigNumber(`0x${thresholdHex}`)
+
+  return threshold.dividedBy(difficulty).toNumber();
+}
+
 /** Validate work parameters. */
 export interface ValidateWorkParams {
   /** The block hash to validate the work against */
@@ -29,20 +87,10 @@ export interface ValidateWorkParams {
 export function validateWork(params: ValidateWorkParams): boolean {
   const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
 
-  if (!checkHash(params.blockHash)) throw new Error('Hash is not valid')
-  if (!checkWork(params.work)) throw new Error('Work is not valid')
   if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
 
+  const difficulty = getWorkDifficulty({ blockHash: params.blockHash, work: params.work });
   const threshold = new BigNumber(`0x${thresholdHex}`)
-  const hashBytes = hexToByteArray(params.blockHash)
-  const workBytes = hexToByteArray(params.work).reverse()
 
-  const context = blake2bInit(8)
-  blake2bUpdate(context, workBytes)
-  blake2bUpdate(context, hashBytes)
-  const output = blake2bFinal(context).reverse()
-  const outputHex = byteArrayToHex(output)
-  const outputBigNumber = new BigNumber(`0x${outputHex}`)
-
-  return outputBigNumber.isGreaterThanOrEqualTo(threshold)
+  return difficulty.isGreaterThanOrEqualTo(threshold);
 }

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -79,6 +79,7 @@ export function validateWork(params: ValidateWorkParams): boolean {
 export interface GetDifficultyMultiplierParams {
   /** The block hash to check the work against */
   difficulty: string
+  /** The threshold to calculate against. Defaults to ffffffc000000000 */
   threshold?: string
 }
 

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -9,6 +9,7 @@ import { checkHash, checkThreshold, checkWork } from './check'
 import { byteArrayToHex, hexToByteArray } from './utils'
 
 export const DEFAULT_WORK_THRESHOLD = 'ffffffc000000000'
+export const MAX_WORK_THRESHOLD = '10000000000000000'
 
 /** Get work difficulty parameters. */
 export interface GetWorkDifficultyParams {
@@ -93,8 +94,8 @@ export function getDifficultyMultiplier(params: GetDifficultyMultiplierParams): 
   if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
   if (!checkThreshold(params.difficulty)) throw new Error('Difficulty is not valid')
 
-  const threshold = new BigNumber(`0x${thresholdHex}`)
-  const difficulty = new BigNumber(`0x${params.difficulty}`)
+  const threshold = new BigNumber(`0x${MAX_WORK_THRESHOLD}`).minus(new BigNumber(`0x${thresholdHex}`))
+  const difficulty = new BigNumber(`0x${MAX_WORK_THRESHOLD}`).minus(new BigNumber(`0x${params.difficulty}`))
 
   return threshold.dividedBy(difficulty).toNumber();
 }

--- a/packages/nanocurrency/src/work.ts
+++ b/packages/nanocurrency/src/work.ts
@@ -91,6 +91,7 @@ export function getDifficultyMultiplier(params: GetDifficultyMultiplierParams): 
   const thresholdHex = params.threshold ?? DEFAULT_WORK_THRESHOLD
 
   if (!checkThreshold(thresholdHex)) throw new Error('Threshold is not valid')
+  if (!checkThreshold(params.difficulty)) throw new Error('Difficulty is not valid')
 
   const threshold = new BigNumber(`0x${thresholdHex}`)
   const difficulty = new BigNumber(`0x${params.difficulty}`)


### PR DESCRIPTION
As requested by @anarkrypto and @PlasmaPower, added `getWorkDifficulty` and `getDifficultyMultiplier` to which return a work's difficulty and a difficulty's multiplier relative to a threshold, and a few related tests. 

I'm unsure if I should rename some instances of `threshold` to `difficulty` e.g. currently using `checkThreshold` to validate difficulty strings as well, and `invalidThreshold` in tests where an invalid difficulty string is needed. 

Only the nanocurrency package is updated, as I'm not sure what the cli commands should be. 